### PR TITLE
Fix entity escaping in rss.xml

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -11,7 +11,7 @@
                     <title>{{ .Title }}</title>
                     <link>{{ .Permalink }}</link>
                     <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-                    <description>{{ .Summary | safeHTML }}</description>
+                    <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
                 </item>
                 {{ end }}
             {{ end }}
@@ -22,7 +22,7 @@
                     <title>{{ .Title }}</title>
                     <link>{{ .Permalink }}</link>
                     <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-                    <description>{{ .Summary | safeHTML }}</description>
+                    <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
                 </item>
                 {{ end }}
             {{ end }}


### PR DESCRIPTION
Fixes the entity escaping in the RSS item description. Uses the same escaping mechanism as the [default Hugo rss template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/rss.xml).

`transform.XMLEscape` requires Hugo 0.121.0 or newer. https://gohugo.io/functions/transform/xmlescape/