### PR TITLE
Parameterized page, header/menu and footer colors.

### DIFF
--- a/assets/scss/_footer.scss
+++ b/assets/scss/_footer.scss
@@ -6,7 +6,7 @@
 	margin-top: 70px;
 	padding-top: 60px;
 	padding-bottom: 60px;
-	background-color: var(--black);
+	background-color: var(--footer-background-color);
 	color: var(--footer-link-color);
 
 	a {

--- a/assets/scss/_global.scss
+++ b/assets/scss/_global.scss
@@ -20,6 +20,10 @@ body {
 	}
 }
 
+.page {
+    backround-color: var(--page-background-color);
+}
+
 .wrap {
 	padding-left: 12px;
 	padding-right: 12px;

--- a/assets/scss/_global.scss
+++ b/assets/scss/_global.scss
@@ -1,6 +1,7 @@
 @use "variables";
 
 body {
+    background-color: var(--page-background-color);
 	overscroll-behavior: none; // fixes menu off bottom of screen.
 	height: auto;
 	max-width: 100%;

--- a/assets/scss/_global.scss
+++ b/assets/scss/_global.scss
@@ -21,7 +21,7 @@ body {
 }
 
 .page {
-    backround-color: var(--page-background-color);
+    background-color: var(--page-background-color);
 }
 
 .wrap {

--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -3,7 +3,7 @@
 
 .header {
     width: 100%;
-    background: var(--white);
+    background-color: var(--menu-background-color);
     z-index: 20;
 
     position: relative;
@@ -80,7 +80,7 @@
 }
 
 .main-menu {
-    background-color: var(--white);
+    background-color: var(--menu-background-color);
     padding-left: 12px;
     padding-right: 12px;
     @media (min-width: 372px) {
@@ -353,7 +353,7 @@
             margin-left: 0; // reset.
             padding-left: 0; // reset.
             @media (min-width: variables.$min-desktop) {
-                background-color: var(--white);
+                background-color: var(--submenu-background-color);
                 border-radius: 12px;
                 border: 1px solid var(--gray-200);
                 box-shadow:

--- a/assets/scss/_language-selector.scss
+++ b/assets/scss/_language-selector.scss
@@ -3,7 +3,7 @@
 .dropdown {
     position: relative;
     border-radius: 6px;
-    background: var(--white);
+    background-color: var(--menu-background-color);
     font-weight: 700;
     line-height: normal;
     font-size: 16px;
@@ -51,7 +51,6 @@
 
 .dropdown-current {
     position: relative;
-    background: var(--white);
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
@@ -120,7 +119,7 @@
     @media (min-width: variables.$min-desktop) {
         border: 1px solid var(--gray-200);
         border-radius: 12px;
-        background-color: var(--white);
+        background-color: var(--submenu-background-color);
     }
 }
 

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -5,13 +5,19 @@
   --rounded-font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, Roboto,
     Ubuntu, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
+  --page-backround-color: var(--white);
   --text-color: var(--black);
   --black: #000000;
   --white: #ffffff;
   --link-color: var(--primary-600);
   --link-color-hover: var(--primary-700);
+
+  --menu-background-color: var(--white);
+  --submenu-background-color: var(--white);
   --menu-link-color: var(--black);
   --menu-link-color-hover: var(--gray-800);
+
+  --footer-background-color: var(--black);
   --footer-link-color: var(--white);
   --footer-link-color-hover: var(--primary-400);
   --gutter: 25px;

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -5,7 +5,7 @@
   --rounded-font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, Roboto,
     Ubuntu, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
-  --page-backround-color: var(--white);
+  --page-background-color: var(--white);
   --text-color: var(--black);
   --black: #000000;
   --white: #ffffff;


### PR DESCRIPTION
Page, header / menu and footer colors are currently hard-coded to `--white` and `--black`.
In order to change any of these colors a user of the theme needs to override portions of the SCSS.
To make things simpler, I added the following color vars: `--page-bacground-color`, `--menu-background-color`, `--submenu-background-color` and `--footer-background-color`.
I updated the relevant SCSS code to use these vars instead of `--white` and `--black`.