### PR TITLE
Parameterized menu link color transition time.

### DIFF
--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -129,7 +129,7 @@
             font-weight: 700;
             line-height: 1;
             letter-spacing: 0.8px;
-            transition: color 0.5s ease;
+            transition: color var(--menu-color-transition-time) ease;
             @media (prefers-reduced-motion: reduce) {
                 transition: none;
             }
@@ -153,7 +153,7 @@
             margin-left: 6px;
             margin-bottom: 3px;
             background-image: url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 10 10' fill='transparent' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 8.778 6.667-6.666M1 1h8v8' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-            transition: filter 0.5s ease;
+            transition: filter var(--menu-color-transition-time) ease;
             @media (prefers-reduced-motion: reduce) {
                 transition: none;
             }
@@ -228,7 +228,7 @@
     .main-menu-search {
         display: block;
         svg {
-            transition: filter 0.5s ease;
+            transition: filter var(--menu-color-transition-time) ease;
             &:hover {
                 filter: invert(38%) sepia(7%) saturate(283%) hue-rotate(169deg) brightness(99%) contrast(94%);
             }

--- a/assets/scss/_language-selector.scss
+++ b/assets/scss/_language-selector.scss
@@ -63,7 +63,7 @@
     line-height: 40px;
     vertical-align: middle;
     padding-right: 20px; // min space for word and chevron.
-    transition: color 0.5s ease;
+    transition: color var(--menu-color-transition-time) ease;
     &:hover {
         color: var(--menu-link-color-hover);
     }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -12,6 +12,7 @@
   --link-color-hover: var(--primary-700);
   --menu-link-color: var(--black);
   --menu-link-color-hover: var(--gray-800);
+  --menu-color-transition-time: 0.5s;
   --footer-link-color: var(--white);
   --footer-link-color-hover: var(--primary-400);
   --gutter: 25px;


### PR DESCRIPTION
The transition between `--menu-link-color` and `--menu-link-color-hover` was hard-coded to 0.5s.
This is quite obnoxious and was difficult to change as a theme user.
I replaced the hard-coded time with a variable for easier adjustment.
In doing so I also used this variable in couple of more places, rather than just the menu links.
E.g. language selector, search icon filter, etc.

In my opinion best would be to remove all these explicit transition timings.
The implementation is very inconsistent and one can notice bugs immediately if any more extreme values are set.
For example, there is a transition defined in the language selector for the selected language (the one showing on the header), but not for the other languages in the drop down.
So while main menu items, submenus, the search, selected language, etc. are all having this animated transition, the languages in the language-selector menu are just regular links that have no transition defined.
The hamburger button is its own story.

I digress.
There is variable now left to the original value of 0.5s, and everyone can set this timing as they desire.