### PR TITLE
Support for V/H alignment in IMG shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Options:
 - alt # (optional) describing the image, defaults to filename
 - width # (optional) recommended
 - height # (optional) recommended
+- h_align # (optional) one of [`align-items`](https://www.w3schools.com/cssref/css3_pr_align-items.php) property values
+- v_align # (optional) one of [`justify-content`](https://www.w3schools.com/cssref/css3_pr_justify-content.php) property values
 - caption # (optional) markdown is accepted
 - loading # (optional) defaults to lazy, use eager above the fold
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ Options:
 ### Img
 
 Inserts an image in a more advanced format than standard Hugo syntax.
+The shortcode wraps the image in a `figure` container, enabling captions.
+You can control the size of the container independent from the image, which
+together with the alignment options allow for more flexible positioning.
 
 ```
 {{< img src="/img/blog/image-name.png" >}}
@@ -233,6 +236,8 @@ Options:
 - alt # (optional) describing the image, defaults to filename
 - width # (optional) recommended
 - height # (optional) recommended
+- f_width # (optional) width of the wrapping figure container
+- f_height # (optional) height of the wrapping figure container
 - h_align # (optional) one of [`align-items`](https://www.w3schools.com/cssref/css3_pr_align-items.php) property values
 - v_align # (optional) one of [`justify-content`](https://www.w3schools.com/cssref/css3_pr_justify-content.php) property values
 - caption # (optional) markdown is accepted

--- a/assets/scss/_images.scss
+++ b/assets/scss/_images.scss
@@ -17,3 +17,10 @@ figcaption {
 	font-size: 14px;
 	color: var(--gray-800);
 }
+
+.image_figure {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}

--- a/assets/scss/_images.scss
+++ b/assets/scss/_images.scss
@@ -21,6 +21,5 @@ figcaption {
 .image_figure {
     display: flex;
     flex-direction: column;
-    height: 100%;
-    width: 100%;
+    flex-grow: 1;
 }

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,7 +1,9 @@
 {{ $src := .Get "src" }}
 {{ $width := .Get "width" | replaceRE "[^0-9]" "" }}
 {{ $height := .Get "height" | replaceRE "[^0-9]" "" }}
-{{ $caption := .Get "caption" }}
+{{ $caption := .Get "caption" | default "" }}
+{{ $h_align := .Get "h_align" | default "normal" }}
+{{ $v_align := .Get "v_align" | default "normal" }}
 {{ $loading := .Get "loading" | default "lazy" }}
 
 {{/* Extract the file name from the path */}}
@@ -30,7 +32,14 @@
 
 {{ if $src }}
   <p>
-  <figure>
+  <!-- empty paragraph for backward alignment
+      compatibility: 2026-01-07
+  -->
+  </p>
+  <figure
+    class="image_figure"
+    style="justify-content: {{ $v_align }}; align-items: {{ $h_align }};"
+      >
   <img
     src="{{ $src }}"
     width="{{ $width }}"
@@ -38,9 +47,6 @@
     alt="{{ $alt | safeHTMLAttr }}"
     loading="{{ $loading }}"
     >
-{{ if $caption}}
   <figcaption>{{ $caption | markdownify }}</figcaption>
-{{ end }}
   </figure>
-  </p>
 {{ end }}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -2,6 +2,8 @@
 {{ $width := .Get "width" | replaceRE "[^0-9]" "" }}
 {{ $height := .Get "height" | replaceRE "[^0-9]" "" }}
 {{ $caption := .Get "caption" | default "" }}
+{{ $f_width := .Get "f_width" | default "auto" }}
+{{ $f_height := .Get "f_height" | default "auto" }}
 {{ $h_align := .Get "h_align" | default "normal" }}
 {{ $v_align := .Get "v_align" | default "normal" }}
 {{ $loading := .Get "loading" | default "lazy" }}
@@ -38,8 +40,8 @@
   </p>
   <figure
     class="image_figure"
-    style="justify-content: {{ $v_align }}; align-items: {{ $h_align }};"
-      >
+    style="justify-content: {{ $v_align }}; align-items: {{ $h_align }}; width: {{ $f_width }}; height: {{ $f_height }};"
+    >
   <img
     src="{{ $src }}"
     width="{{ $width }}"

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -29,10 +29,8 @@
 {{ end }}
 
 {{ if $src }}
-
-{{ if $caption}}
+  <p>
   <figure>
-{{ end }}
   <img
     src="{{ $src }}"
     width="{{ $width }}"
@@ -42,7 +40,7 @@
     >
 {{ if $caption}}
   <figcaption>{{ $caption | markdownify }}</figcaption>
-  </figure>
 {{ end }}
-
+  </figure>
+  </p>
 {{ end }}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -32,7 +32,7 @@
 
 {{ if $caption}}
   <figure>
-  {{ end }}
+{{ end }}
   <img
     src="{{ $src }}"
     width="{{ $width }}"
@@ -40,8 +40,8 @@
     alt="{{ $alt | safeHTMLAttr }}"
     loading="{{ $loading }}"
     >
-  {{ if $caption}}
-    <figcaption>{{ $caption | markdownify }}</figcaption>
+{{ if $caption}}
+  <figcaption>{{ $caption | markdownify }}</figcaption>
   </figure>
 {{ end }}
 


### PR DESCRIPTION
The first commit is a bugfix, as figure captions were not injected properly in the template.
In case you don't like the rest you can cherry pick that commit.

Beside adding the alignment support, I also modified a bit how the `<figure>` and `<figcaption>` tags were managed.
I couldn't figure out why Hugo is injecting `<p>` tags in between, so I ended up removing the condition and always adding the figure wrapper around the image as well as the caption beneath it.
As they don't introduce any paddings or margins, visually this doesn't seem to make any difference.

To keep the alignment backward compatible (there was a slight padding introduced due to the image being wrapped in `<p>`), I added an empty paragraph above the figure.
At least this preserves the alignment of the hero section in the example site, but I am unsure if it would be 100% backward compatible in all situations.