### PR TITLE
Menu rendering bugfix (issue #70)

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -39,4 +39,4 @@
 // Define SCSS variables.
 $desktop-width: calc(1200px + 25px + 25px);
 $min-desktop: 1000px;
-$mobile-max: 999px;
+$mobile-max: 999.999px;


### PR DESCRIPTION
This is a dirty hack that virtually solves the issue but in essence the bug is still present.

The correct fix would be to rework the SCSS according to: https://stackoverflow.com/questions/13241531/what-are-the-rules-for-css-media-query-overlap